### PR TITLE
feat(WMG-5): familyId rules and optional auto-generation on register

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ npm run dev
 
 Protected routes require an `Authorization: Bearer <token>` header. The token is returned by the register and login endpoints.
 
+## Family ID (`familyId`)
+
+Each user belongs to one family; transactions are scoped by the `familyId` embedded in the JWT.
+
+- **Registration**: `familyId` is optional. If you omit it or send an empty string, the API assigns a new id (format `fam-` plus 24 hex characters) and returns it with the user payload and token.
+- **Joining an existing family**: send a `familyId` chosen by your product (for example a code shared between members). It must be a **lowercase slug**: 3–50 characters, letters and digits only, with optional single hyphens between segments (no leading/trailing hyphen, no underscores or spaces). Values are stored normalized in lowercase.
+- **Login**: unchanged; `familyId` always comes from the stored user record.
+
 ## Categories
 
 Transactions accept only these categories:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Where Did Our Money Go API
-  version: 0.2.0
+  version: 0.3.0
   description: REST API for shared personal expense tracking.
 servers:
   - url: http://localhost:3000
@@ -166,7 +166,6 @@ components:
         - name
         - email
         - password
-        - familyId
       properties:
         name:
           type: string
@@ -181,6 +180,9 @@ components:
           example: strong-password
         familyId:
           type: string
+          description: >
+            Optional. Lowercase slug (3–50 chars, letters, digits, hyphens between segments).
+            Omit or send empty to create a new family; the API returns the assigned id in the response and JWT.
           example: family-main
     LoginRequest:
       type: object

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -4,6 +4,7 @@ const jwt = require('jsonwebtoken');
 const { connectDatabase } = require('../config/database');
 const env = require('../config/env');
 const User = require('../models/user.model');
+const { resolveFamilyIdForRegistration } = require('../utils/familyId.util');
 
 function buildAuthResponse(user) {
   const token = jwt.sign(
@@ -38,13 +39,15 @@ async function registerUser(payload) {
     throw error;
   }
 
-  const { name, email, password, familyId } = payload;
+  const { name, email, password } = payload;
 
-  if (!name || !email || !password || !familyId) {
-    const error = new Error('name, email, password and familyId are required');
+  if (!name || !email || !password) {
+    const error = new Error('name, email and password are required');
     error.statusCode = 400;
     throw error;
   }
+
+  const familyId = resolveFamilyIdForRegistration(payload.familyId);
 
   const existingUser = await User.findOne({ email });
 

--- a/src/utils/familyId.util.js
+++ b/src/utils/familyId.util.js
@@ -1,0 +1,48 @@
+const crypto = require('crypto');
+
+const MIN_LEN = 3;
+const MAX_LEN = 50;
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function createValidationError(message) {
+  const err = new Error(message);
+  err.statusCode = 400;
+  return err;
+}
+
+function generateFamilyId() {
+  return `fam-${crypto.randomBytes(12).toString('hex')}`;
+}
+
+function validateUserProvidedFamilyId(raw) {
+  const normalized = String(raw).trim().toLowerCase();
+  if (normalized.length < MIN_LEN || normalized.length > MAX_LEN) {
+    throw createValidationError(
+      `familyId must be between ${MIN_LEN} and ${MAX_LEN} characters`
+    );
+  }
+  if (!SLUG_PATTERN.test(normalized)) {
+    throw createValidationError(
+      'familyId must be a lowercase slug: letters, digits, and internal hyphens only'
+    );
+  }
+  return normalized;
+}
+
+function resolveFamilyIdForRegistration(familyIdInput) {
+  if (familyIdInput === undefined || familyIdInput === null) {
+    return generateFamilyId();
+  }
+  if (typeof familyIdInput === 'string' && familyIdInput.trim() === '') {
+    return generateFamilyId();
+  }
+  return validateUserProvidedFamilyId(familyIdInput);
+}
+
+module.exports = {
+  MIN_LEN,
+  MAX_LEN,
+  generateFamilyId,
+  validateUserProvidedFamilyId,
+  resolveFamilyIdForRegistration
+};

--- a/tests/unit/auth.service.test.js
+++ b/tests/unit/auth.service.test.js
@@ -152,6 +152,122 @@ test('registerUser fails when email already exists', async () => {
   assert.equal(connectCalls, 1);
 });
 
+test('registerUser assigns generated familyId when familyId is omitted', async () => {
+  let createdFamilyId;
+
+  const authService = withMockedModules(
+    {
+      [databasePath]: {
+        connectDatabase: async () => {}
+      },
+      [envPath]: { jwtSecret: 'test-secret', jwtExpiresIn: '2h' },
+      [userPath]: {
+        findOne: async () => null,
+        create: async (payload) => {
+          createdFamilyId = payload.familyId;
+          return {
+            id: 'u-new',
+            name: payload.name,
+            email: payload.email,
+            familyId: payload.familyId
+          };
+        }
+      },
+      [bcryptPath]: {
+        hash: async (password) => `hashed:${password}`
+      },
+      [jwtPath]: {
+        sign: () => 'signed-jwt'
+      }
+    },
+    () => require(servicePath)
+  );
+
+  const result = await authService.registerUser({
+    name: 'Solo',
+    email: 'solo@example.com',
+    password: 'secret'
+  });
+
+  assert.match(createdFamilyId, /^fam-[a-f0-9]{24}$/);
+  assert.equal(result.user.familyId, createdFamilyId);
+});
+
+test('registerUser normalizes provided familyId', async () => {
+  let createdFamilyId;
+
+  const authService = withMockedModules(
+    {
+      [databasePath]: {
+        connectDatabase: async () => {}
+      },
+      [envPath]: { jwtSecret: 'test-secret', jwtExpiresIn: '2h' },
+      [userPath]: {
+        findOne: async () => null,
+        create: async (payload) => {
+          createdFamilyId = payload.familyId;
+          return {
+            id: 'u-join',
+            name: payload.name,
+            email: payload.email,
+            familyId: payload.familyId
+          };
+        }
+      },
+      [bcryptPath]: {
+        hash: async (password) => `hashed:${password}`
+      },
+      [jwtPath]: {
+        sign: () => 'signed-jwt'
+      }
+    },
+    () => require(servicePath)
+  );
+
+  await authService.registerUser({
+    name: 'Member',
+    email: 'member@example.com',
+    password: 'secret',
+    familyId: '  Shared-Kitchen  '
+  });
+
+  assert.equal(createdFamilyId, 'shared-kitchen');
+});
+
+test('registerUser rejects invalid familyId slug', async () => {
+  const authService = withMockedModules(
+    {
+      [databasePath]: {
+        connectDatabase: async () => {}
+      },
+      [envPath]: { jwtSecret: 'test-secret', jwtExpiresIn: '1d' },
+      [userPath]: {
+        findOne: async () => null,
+        create: async () => {
+          throw new Error('create should not run');
+        }
+      },
+      [bcryptPath]: { hash: async () => 'ignored' },
+      [jwtPath]: { sign: () => 'ignored' }
+    },
+    () => require(servicePath)
+  );
+
+  await assert.rejects(
+    () => authService.registerUser({
+      name: 'Bad',
+      email: 'bad@example.com',
+      password: 'secret',
+      familyId: 'no'
+    }),
+    (error) => {
+      assert.equal(error.statusCode, 400);
+      assert.match(error.message, /familyId/);
+      return true;
+    }
+  );
+});
+
 test('loginUser returns jwt when credentials are valid', async () => {
   let connectCalls = 0;
 

--- a/tests/unit/familyId.util.test.js
+++ b/tests/unit/familyId.util.test.js
@@ -1,0 +1,84 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  MIN_LEN,
+  MAX_LEN,
+  generateFamilyId,
+  validateUserProvidedFamilyId,
+  resolveFamilyIdForRegistration
+} = require('../../src/utils/familyId.util');
+
+test('generateFamilyId returns fam- prefix and 24 hex chars', () => {
+  const id = generateFamilyId();
+  assert.match(id, /^fam-[a-f0-9]{24}$/);
+});
+
+test('validateUserProvidedFamilyId normalizes to lowercase slug', () => {
+  assert.equal(validateUserProvidedFamilyId('  Family-Main  '), 'family-main');
+});
+
+test('validateUserProvidedFamilyId accepts minimum length slug', () => {
+  assert.equal(validateUserProvidedFamilyId('abc'), 'abc');
+});
+
+test('validateUserProvidedFamilyId rejects slug shorter than minimum', () => {
+  assert.throws(
+    () => validateUserProvidedFamilyId('ab'),
+    (error) => {
+      assert.equal(error.statusCode, 400);
+      assert.match(error.message, new RegExp(String.raw`${MIN_LEN}`));
+      return true;
+    }
+  );
+});
+
+test('validateUserProvidedFamilyId rejects slug longer than maximum', () => {
+  const tooLong = 'a'.repeat(MAX_LEN + 1);
+  assert.throws(
+    () => validateUserProvidedFamilyId(tooLong),
+    (error) => {
+      assert.equal(error.statusCode, 400);
+      return true;
+    }
+  );
+});
+
+test('validateUserProvidedFamilyId rejects underscores and spaces', () => {
+  assert.throws(
+    () => validateUserProvidedFamilyId('family_main'),
+    (error) => {
+      assert.equal(error.statusCode, 400);
+      return true;
+    }
+  );
+});
+
+test('validateUserProvidedFamilyId rejects double hyphen segments', () => {
+  assert.throws(
+    () => validateUserProvidedFamilyId('fam--ily'),
+    (error) => {
+      assert.equal(error.statusCode, 400);
+      return true;
+    }
+  );
+});
+
+test('resolveFamilyIdForRegistration generates when input is undefined', () => {
+  const id = resolveFamilyIdForRegistration(undefined);
+  assert.match(id, /^fam-[a-f0-9]{24}$/);
+});
+
+test('resolveFamilyIdForRegistration generates when input is null', () => {
+  const id = resolveFamilyIdForRegistration(null);
+  assert.match(id, /^fam-[a-f0-9]{24}$/);
+});
+
+test('resolveFamilyIdForRegistration generates when input is blank string', () => {
+  const id = resolveFamilyIdForRegistration('   ');
+  assert.match(id, /^fam-[a-f0-9]{24}$/);
+});
+
+test('resolveFamilyIdForRegistration validates when input is non-empty', () => {
+  assert.equal(resolveFamilyIdForRegistration('Shared-Home'), 'shared-home');
+});


### PR DESCRIPTION
- Add familyId util: slug validation (3-50 chars), normalization, fam-* generation
- Register accepts optional familyId; omit or empty string creates new family id
- Document in README and OpenAPI 0.3.0
- Unit tests for util and auth register paths